### PR TITLE
Calculates 'weights' path relative to current file

### DIFF
--- a/predict.py
+++ b/predict.py
@@ -177,7 +177,8 @@ def run_merizo():
     device = get_device(args.device)
     network = Merizo().to(device)
 
-    network.load_state_dict(read_split_weight_files('./weights/'), strict=True)
+    weights_dir = os.path.join(os.path.dirname(__file__), 'weights')
+    network.load_state_dict(read_split_weight_files(weights_dir), strict=True)
     network.eval()
 
     for pdb_path in args.input:


### PR DESCRIPTION
I have a use case where it is more convenient to be in a different directory when running this script. 

This change means that the script no longer needs to be run from the repo root.